### PR TITLE
Fix: Bug report URL is incorrect

### DIFF
--- a/custom_components/contact_energy/manifest.json
+++ b/custom_components/contact_energy/manifest.json
@@ -9,7 +9,7 @@
 	],
 	"documentation": "https://github.com/codyc1515/ha-contact-energy",
 	"iot_class": "cloud_polling",
-	"issue_tracker": "https://github.com/codyc15/ha-contact-energy/issues",
+	"issue_tracker": "https://github.com/codyc1515/ha-contact-energy/issues",
 	"requirements": [],
 	"version": "1.0.0"
 }


### PR DESCRIPTION
issue_tracker key has a typo in the value
This is causing a 404 when clicking the link in the logs.